### PR TITLE
OCPBUGS-48485: Use downstream version of rbac-proxy

### DIFF
--- a/bundle/manifests/pf-status-relay-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/pf-status-relay-operator.clusterserviceversion.yaml
@@ -177,7 +177,7 @@ spec:
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=0
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0
+                image: quay.io/openshift/origin-kube-rbac-proxy:4.19.0
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -15,7 +15,7 @@ spec:
           capabilities:
             drop:
             - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0
+        image: quay.io/openshift/origin-kube-rbac-proxy:4.19.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/hack/align-ocp-version.sh
+++ b/hack/align-ocp-version.sh
@@ -3,10 +3,12 @@ set -e
 export VERSION="4.19.0"
 
 sed -i 's/quay.io\/openshift\/origin-pf-status-relay:.*$/quay.io\/openshift\/origin-pf-status-relay:'$VERSION'/g' config/manager/env_patch.yaml
+sed -i 's/quay.io\/openshift\/origin-kube-rbac-proxy:.*$/quay.io\/openshift\/origin-kube-rbac-proxy:'$VERSION'/g' config/default/manager_auth_proxy_patch.yaml
 make bundle
 
 cp bundle/manifests/* manifests/stable
 
+sed -i 's/quay.io\/openshift\/origin-kube-rbac-proxy:.*$/quay.io\/openshift\/origin-kube-rbac-proxy:'$VERSION'/g' manifests/stable/image-references
 sed -i 's/quay.io\/openshift\/origin-pf-status-relay:.*$/quay.io\/openshift\/origin-pf-status-relay:'$VERSION'/g' manifests/stable/image-references
 sed -i 's/quay.io\/openshift\/origin-pf-status-relay-operator:.*$/quay.io\/openshift\/origin-pf-status-relay-operator:'$VERSION'/g' manifests/stable/image-references
 sed -i 's/pf-status-relay-operator\..*$/pf-status-relay-operator\.v'$VERSION'/g' manifests/pf-status-relay-operator.package.yaml

--- a/manifests/stable/image-references
+++ b/manifests/stable/image-references
@@ -11,3 +11,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-pf-status-relay:4.19.0
+  - name: kube-rbac-proxy
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-kube-rbac-proxy:4.19.0

--- a/manifests/stable/pf-status-relay-operator.clusterserviceversion.yaml
+++ b/manifests/stable/pf-status-relay-operator.clusterserviceversion.yaml
@@ -177,7 +177,7 @@ spec:
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=0
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0
+                image: quay.io/openshift/origin-kube-rbac-proxy:4.19.0
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443


### PR DESCRIPTION
Fixes https://github.com/openshift/pf-status-relay-operator/issues/28