### PR TITLE
Fix make deploy for OCP

### DIFF
--- a/bundle/manifests/pf-status-relay-operator-webhook-service_v1_service.yaml
+++ b/bundle/manifests/pf-status-relay-operator-webhook-service_v1_service.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: webhook-server-cert
   creationTimestamp: null
   labels:
     app.kubernetes.io/managed-by: kustomize

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -37,6 +37,9 @@ patches:
 # crd/kustomization.yaml
 - path: manager_webhook_patch.yaml
 
+# [WEBHOOK] Add a service certificate Openshift
+- path: webhookservingcert_patch.yaml
+
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -28,6 +28,8 @@ resources:
 - ../pf_status_relay_rbac
 
 patches:
+# Add Openshift namespace labels
+- path: namespace_patch.yaml
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -43,7 +43,8 @@ patches:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection
-#- path: webhookcainjection_patch.yaml
+# Openshift CA injection is used
+- path: webhookcainjection_patch.yaml
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
 # Uncomment the following replacements to add the cert-manager CA injection annotations

--- a/config/default/namespace_patch.yaml
+++ b/config/default/namespace_patch.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: system
+  labels:
+    security.openshift.io/scc.podSecurityLabelSync: "false"
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
+    pod-security.kubernetes.io/audit: privileged

--- a/config/default/webhookcainjection_patch.yaml
+++ b/config/default/webhookcainjection_patch.yaml
@@ -1,15 +1,15 @@
 # This patch add annotation to admission webhook config and
 # CERTIFICATE_NAMESPACE and CERTIFICATE_NAME will be substituted by kustomize
-apiVersion: admissionregistration.k8s.io/v1
-kind: MutatingWebhookConfiguration
-metadata:
-  labels:
-    app.kubernetes.io/name: pf-status-relay-operator
-    app.kubernetes.io/managed-by: kustomize
-  name: mutating-webhook-configuration
-  annotations:
-    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
----
+#apiVersion: admissionregistration.k8s.io/v1
+#kind: MutatingWebhookConfiguration
+#metadata:
+#  labels:
+#    app.kubernetes.io/name: pf-status-relay-operator
+#    app.kubernetes.io/managed-by: kustomize
+#  name: mutating-webhook-configuration
+#  annotations:
+#    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
+#---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -22,4 +22,5 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
   name: validating-webhook-configuration
   annotations:
-    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
+    service.beta.openshift.io/inject-cabundle: "true"
+  #   cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME

--- a/config/default/webhookservingcert_patch.yaml
+++ b/config/default/webhookservingcert_patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: webhook-service
+  namespace: system
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: webhook-server-cert

--- a/manifests/stable/pf-status-relay-operator-webhook-service_v1_service.yaml
+++ b/manifests/stable/pf-status-relay-operator-webhook-service_v1_service.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: webhook-server-cert
   creationTimestamp: null
   labels:
     app.kubernetes.io/managed-by: kustomize


### PR DESCRIPTION
This ensure make deploy can run the operator on an OCP cluster