### PR TITLE
Set OwnNamespace as InstallMode

### DIFF
--- a/bundle/manifests/pf-status-relay-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/pf-status-relay-operator.clusterserviceversion.yaml
@@ -267,17 +267,6 @@ spec:
   - admissionReviewVersions:
     - v1
     containerPort: 443
-    conversionCRDs:
-    - pflacpmonitors.pfstatusrelay.openshift.io
-    deploymentName: pf-status-relay-operator-controller-manager
-    generateName: cpflacpmonitors.kb.io
-    sideEffects: None
-    targetPort: 9443
-    type: ConversionWebhook
-    webhookPath: /convert
-  - admissionReviewVersions:
-    - v1
-    containerPort: 443
     deploymentName: pf-status-relay-operator-controller-manager
     failurePolicy: Fail
     generateName: vpflacpmonitor.kb.io

--- a/bundle/manifests/pf-status-relay-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/pf-status-relay-operator.clusterserviceversion.yaml
@@ -240,13 +240,13 @@ spec:
         serviceAccountName: pf-status-relay-operator-controller-manager
     strategy: deployment
   installModes:
-  - supported: false
+  - supported: true
     type: OwnNamespace
   - supported: false
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: true
+  - supported: false
     type: AllNamespaces
   keywords:
   - pf-status-relay

--- a/bundle/manifests/pfstatusrelay.openshift.io_pflacpmonitors.yaml
+++ b/bundle/manifests/pfstatusrelay.openshift.io_pflacpmonitors.yaml
@@ -6,16 +6,6 @@ metadata:
   creationTimestamp: null
   name: pflacpmonitors.pfstatusrelay.openshift.io
 spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          name: pf-status-relay-operator-webhook-service
-          namespace: openshift-pf-status-relay-operator
-          path: /convert
-      conversionReviewVersions:
-      - v1
   group: pfstatusrelay.openshift.io
   names:
     kind: PFLACPMonitor

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
 patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
-- path: patches/webhook_in_pflacpmonitors.yaml
+#- path: patches/webhook_in_pflacpmonitors.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.

--- a/config/manifests/bases/pf-status-relay-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/pf-status-relay-operator.clusterserviceversion.yaml
@@ -33,13 +33,13 @@ spec:
       deployments: null
     strategy: ""
   installModes:
-  - supported: false
+  - supported: true
     type: OwnNamespace
   - supported: false
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: true
+  - supported: false
     type: AllNamespaces
   keywords:
   - pf-status-relay

--- a/manifests/stable/pf-status-relay-operator.clusterserviceversion.yaml
+++ b/manifests/stable/pf-status-relay-operator.clusterserviceversion.yaml
@@ -267,17 +267,6 @@ spec:
   - admissionReviewVersions:
     - v1
     containerPort: 443
-    conversionCRDs:
-    - pflacpmonitors.pfstatusrelay.openshift.io
-    deploymentName: pf-status-relay-operator-controller-manager
-    generateName: cpflacpmonitors.kb.io
-    sideEffects: None
-    targetPort: 9443
-    type: ConversionWebhook
-    webhookPath: /convert
-  - admissionReviewVersions:
-    - v1
-    containerPort: 443
     deploymentName: pf-status-relay-operator-controller-manager
     failurePolicy: Fail
     generateName: vpflacpmonitor.kb.io

--- a/manifests/stable/pf-status-relay-operator.clusterserviceversion.yaml
+++ b/manifests/stable/pf-status-relay-operator.clusterserviceversion.yaml
@@ -240,13 +240,13 @@ spec:
         serviceAccountName: pf-status-relay-operator-controller-manager
     strategy: deployment
   installModes:
-  - supported: false
+  - supported: true
     type: OwnNamespace
   - supported: false
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: true
+  - supported: false
     type: AllNamespaces
   keywords:
   - pf-status-relay

--- a/manifests/stable/pfstatusrelay.openshift.io_pflacpmonitors.yaml
+++ b/manifests/stable/pfstatusrelay.openshift.io_pflacpmonitors.yaml
@@ -6,16 +6,6 @@ metadata:
   creationTimestamp: null
   name: pflacpmonitors.pfstatusrelay.openshift.io
 spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          name: pf-status-relay-operator-webhook-service
-          namespace: openshift-pf-status-relay-operator
-          path: /convert
-      conversionReviewVersions:
-      - v1
   group: pfstatusrelay.openshift.io
   names:
     kind: PFLACPMonitor


### PR DESCRIPTION
Operator only needs to watch its own namespace. The conversion webhook is removed since it is not used and forced AllNamespaces as InstallMode.