### PR TITLE
Add network policies for operator and operand

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ endif
 
 # Set the Operator SDK version to use. By default, what is installed on the system is used.
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
-OPERATOR_SDK_VERSION ?= v1.37.0
+OPERATOR_SDK_VERSION ?= v1.40.0
 # Image URL to use all building/pushing image targets
 IMG ?= quay.io/openshift/origin-pf-status-relay-operator:$(VERSION)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,7 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=pf-status-relay-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.37.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.40.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
 

--- a/bundle/manifests/pf-status-relay-operator-deny-all_networking.k8s.io_v1_networkpolicy.yaml
+++ b/bundle/manifests/pf-status-relay-operator-deny-all_networking.k8s.io_v1_networkpolicy.yaml
@@ -1,0 +1,9 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: pf-status-relay-operator-deny-all
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress

--- a/bundle/manifests/pf-status-relay-operator-operator-allow-egress-to-api-server_networking.k8s.io_v1_networkpolicy.yaml
+++ b/bundle/manifests/pf-status-relay-operator-operator-allow-egress-to-api-server_networking.k8s.io_v1_networkpolicy.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: pf-status-relay-operator-operator-allow-egress-to-api-server
+spec:
+  egress:
+  - ports:
+    - port: 6443
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes:
+  - Egress

--- a/bundle/manifests/pf-status-relay-operator-operator-allow-from-api-server-to-webhook_networking.k8s.io_v1_networkpolicy.yaml
+++ b/bundle/manifests/pf-status-relay-operator-operator-allow-from-api-server-to-webhook_networking.k8s.io_v1_networkpolicy.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: pf-status-relay-operator-operator-allow-from-api-server-to-webhook
+spec:
+  ingress:
+  - ports:
+    - port: 9443
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes:
+  - Ingress

--- a/bundle/manifests/pf-status-relay-operator-operator-allow-to-dns_networking.k8s.io_v1_networkpolicy.yaml
+++ b/bundle/manifests/pf-status-relay-operator-operator-allow-to-dns_networking.k8s.io_v1_networkpolicy.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: pf-status-relay-operator-operator-allow-to-dns
+spec:
+  egress:
+  - ports:
+    - port: 53
+      protocol: TCP
+    - port: 53
+      protocol: UDP
+    to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-dns
+      podSelector:
+        matchLabels:
+          dns.operator.openshift.io/daemonset-dns: default
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes:
+  - Egress

--- a/bundle/manifests/pf-status-relay-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/pf-status-relay-operator.clusterserviceversion.yaml
@@ -26,7 +26,7 @@ metadata:
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
     olm.skipRange: '>=4.3.0-0 <4.19.0'
-    operators.operatorframework.io/builder: operator-sdk-v1.37.0
+    operators.operatorframework.io/builder: operator-sdk-v1.40.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: pf-status-relay-operator.v4.20.0
   namespace: placeholder

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,7 +5,7 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: pf-status-relay-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.37.0
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.40.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4
 

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -26,6 +26,7 @@ resources:
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 - ../pf_status_relay_rbac
+- ../networkpolicies
 
 patches:
 # Add Openshift namespace labels

--- a/config/networkpolicies/deny_all.yaml
+++ b/config/networkpolicies/deny_all.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: deny-all
+  namespace: system
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress

--- a/config/networkpolicies/kustomization.yaml
+++ b/config/networkpolicies/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - operator.yaml
+  - deny_all.yaml

--- a/config/networkpolicies/operator.yaml
+++ b/config/networkpolicies/operator.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: operator-allow-egress-to-api-server
+  namespace: system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  egress:
+    - ports:
+        - protocol: TCP
+          port: 6443
+  policyTypes:
+    - Egress
+
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: operator-allow-to-dns
+  namespace: system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+          podSelector:
+            matchLabels:
+              dns.operator.openshift.io/daemonset-dns: default
+      ports:
+      - protocol: TCP
+        port: 53
+      - protocol: UDP
+        port: 53
+  policyTypes:
+    - Egress
+
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: operator-allow-from-api-server-to-webhook
+  namespace: system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: 9443
+  policyTypes:
+    - Ingress

--- a/internal/controller/pflacpmonitor_controller.go
+++ b/internal/controller/pflacpmonitor_controller.go
@@ -40,7 +40,7 @@ import (
 const (
 	pfStatusRelaySAName = "pf-status-relay-operator-pf-status-relay"
 
-	namePrefix = "pf-status-relay"
+	operandName = "pf-status-relay"
 )
 
 // PFLACPMonitorReconciler reconciles a PFLACPMonitor object
@@ -126,7 +126,7 @@ func (r *PFLACPMonitorReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 func (r *PFLACPMonitorReconciler) syncDaemonSet(ctx context.Context, pfMonitor *pfstatusrelayv1alpha1.PFLACPMonitor) error {
 	log.Log.Info("syncing daemonset", "name", pfMonitor.Name, "namespace", pfMonitor.Namespace)
 
-	name := fmt.Sprintf("%s-ds-%s", namePrefix, pfMonitor.Name)
+	name := fmt.Sprintf("%s-ds-%s", operandName, pfMonitor.Name)
 	image, err := getDaemonSetImage()
 	if err != nil {
 		return err
@@ -214,7 +214,7 @@ func (r *PFLACPMonitorReconciler) syncDaemonSet(ctx context.Context, pfMonitor *
 }
 
 func (r *PFLACPMonitorReconciler) deleteDaemonSet(ctx context.Context, pfMonitor *pfstatusrelayv1alpha1.PFLACPMonitor) error {
-	name := fmt.Sprintf("%s-ds-%s", namePrefix, pfMonitor.Name)
+	name := fmt.Sprintf("%s-ds-%s", operandName, pfMonitor.Name)
 	ds := &appsv1.DaemonSet{}
 	err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: pfMonitor.Namespace}, ds)
 	if err != nil {

--- a/internal/controller/pflacpmonitor_controller_test.go
+++ b/internal/controller/pflacpmonitor_controller_test.go
@@ -57,7 +57,7 @@ var _ = Describe("PFLACPMonitor Controller", func() {
 
 		BeforeEach(func() {
 			By("creating the custom resource for the Kind PFLACPMonitor")
-			dsName = fmt.Sprintf("%s-ds-%s", namePrefix, typeNamespacedName.Name)
+			dsName = fmt.Sprintf("%s-ds-%s", operandName, typeNamespacedName.Name)
 			envVars = []corev1.EnvVar{
 				{
 					Name:  "PF_STATUS_RELAY_INTERFACES",
@@ -150,7 +150,7 @@ var _ = Describe("PFLACPMonitor Controller", func() {
 			It("should modify Degraded status appropriately", func() {
 				newName := "new-monitor"
 				namespace := "default"
-				dsName := fmt.Sprintf("%s-ds-%s", namePrefix, newName)
+				dsName := fmt.Sprintf("%s-ds-%s", operandName, newName)
 
 				By("creating a new PFLACPMonitor resource")
 				newPFLACPMonitor := &pfstatusrelayv1alpha1.PFLACPMonitor{

--- a/manifests/stable/pf-status-relay-operator-deny-all_networking.k8s.io_v1_networkpolicy.yaml
+++ b/manifests/stable/pf-status-relay-operator-deny-all_networking.k8s.io_v1_networkpolicy.yaml
@@ -1,0 +1,9 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: pf-status-relay-operator-deny-all
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress

--- a/manifests/stable/pf-status-relay-operator-operator-allow-egress-to-api-server_networking.k8s.io_v1_networkpolicy.yaml
+++ b/manifests/stable/pf-status-relay-operator-operator-allow-egress-to-api-server_networking.k8s.io_v1_networkpolicy.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: pf-status-relay-operator-operator-allow-egress-to-api-server
+spec:
+  egress:
+  - ports:
+    - port: 6443
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes:
+  - Egress

--- a/manifests/stable/pf-status-relay-operator-operator-allow-from-api-server-to-webhook_networking.k8s.io_v1_networkpolicy.yaml
+++ b/manifests/stable/pf-status-relay-operator-operator-allow-from-api-server-to-webhook_networking.k8s.io_v1_networkpolicy.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: pf-status-relay-operator-operator-allow-from-api-server-to-webhook
+spec:
+  ingress:
+  - ports:
+    - port: 9443
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes:
+  - Ingress

--- a/manifests/stable/pf-status-relay-operator-operator-allow-to-dns_networking.k8s.io_v1_networkpolicy.yaml
+++ b/manifests/stable/pf-status-relay-operator-operator-allow-to-dns_networking.k8s.io_v1_networkpolicy.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: pf-status-relay-operator-operator-allow-to-dns
+spec:
+  egress:
+  - ports:
+    - port: 53
+      protocol: TCP
+    - port: 53
+      protocol: UDP
+    to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-dns
+      podSelector:
+        matchLabels:
+          dns.operator.openshift.io/daemonset-dns: default
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes:
+  - Egress

--- a/manifests/stable/pf-status-relay-operator.clusterserviceversion.yaml
+++ b/manifests/stable/pf-status-relay-operator.clusterserviceversion.yaml
@@ -26,7 +26,7 @@ metadata:
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
     olm.skipRange: '>=4.3.0-0 <4.19.0'
-    operators.operatorframework.io/builder: operator-sdk-v1.37.0
+    operators.operatorframework.io/builder: operator-sdk-v1.40.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: pf-status-relay-operator.v4.20.0
   namespace: placeholder


### PR DESCRIPTION
Operator has an egress to api-server and ingress to its webhook.
Operand does not need any.