### PR TITLE
Group dependabot updates by package origin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,21 @@ updates:
     directory: /
     schedule:
       interval: daily
+    groups:
+      k8s:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+      openshift:
+        patterns:
+          - "github.com/openshift/*"
+      other-go-modules:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+          - "github.com/openshift/*"
   - package-ecosystem: docker
     directory: /
     schedule:


### PR DESCRIPTION
## Summary

- Add k8s and openshift groups to consolidate related package updates into single PRs
- Groups `k8s.io/*` and `sigs.k8s.io/*` packages together for coordinated updates
- Groups `github.com/openshift/*` packages together
- Catches remaining dependencies in `other-go-modules` group

This reduces PR noise and makes dependency updates easier to review.

## Related PRs

This change is part of a coordinated effort across multiple OpenShift repositories:

- openshift/kube-compare#253
- openshift/assisted-service#8716
- openshift/backplane-cli#873
- openshift/cluster-openshift-apiserver-operator#636
- openshift/containernetworking-plugins#221
- openshift/ingress-node-firewall#690
- openshift/oc-mirror#1336
- openshift/pf-status-relay-operator#51 (this PR)

Tracked by: [CNFCERT-1301](https://issues.redhat.com/browse/CNFCERT-1301)

## Test plan

- [ ] Verify dependabot.yml syntax is valid
- [ ] Wait for next dependabot run to confirm groups are applied correctly

🤖 Generated with [Claude Code](https://claude.ai/code)