### PR TITLE
Upgrade golangci-lint from v1 to v2.11.4

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,21 +1,7 @@
+version: "2"
 run:
   timeout: 5m
   allow-parallel-runners: true
-
-issues:
-  # don't skip warning about doc comments
-  # don't exclude the default set of lint
-  exclude-use-default: false
-  # restore some of the defaults
-  # (fill in the rest as needed)
-  exclude-rules:
-    - path: "api/*"
-      linters:
-        - lll
-    - path: "internal/*"
-      linters:
-        - dupl
-        - lll
 linters:
   disable-all: true
   enable:
@@ -24,8 +10,6 @@ linters:
     - copyloopvar
     - goconst
     - gocyclo
-    - gofmt
-    - goimports
     - gosimple
     - govet
     - ineffassign
@@ -38,3 +22,19 @@ linters:
     - unconvert
     - unparam
     - unused
+  exclusions:
+    # don't skip warning about doc comments
+    # don't exclude the default set of lint
+    preset: none
+    rules:
+      - path: "api/*"
+        linters:
+          - lll
+      - path: "internal/*"
+        linters:
+          - dupl
+          - lll
+formatters:
+  enable:
+    - gofmt
+    - goimports

--- a/Makefile
+++ b/Makefile
@@ -212,7 +212,7 @@ GOLANGCI_LINT = $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
 KUSTOMIZE_VERSION ?= v5.3.0
 CONTROLLER_TOOLS_VERSION ?= v0.14.0
 ENVTEST_VERSION ?= release-0.22
-GOLANGCI_LINT_VERSION ?= v1.61.0
+GOLANGCI_LINT_VERSION ?= v2.11.4
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
@@ -232,7 +232,7 @@ $(ENVTEST): $(LOCALBIN)
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,${GOLANGCI_LINT_VERSION})
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,${GOLANGCI_LINT_VERSION})
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary (ideally with version)


### PR DESCRIPTION
## Summary
- Upgrade golangci-lint from v1.61.0 to v2.11.4
- Update module path to include `/v2/` prefix
- Migrate `.golangci.yml` to v2 format:
  - Add `version: "2"` declaration
  - Move formatters (gofmt, goimports) to `formatters.enable` section
  - Convert `issues.exclude-rules` to `linters.exclusions.rules`

**Note:** This PR may require a corresponding change in the openshift/release repo to update Prow CI configurations, similar to https://github.com/openshift/release/pull/72623

Tracking: https://github.com/redhat-best-practices-for-k8s/telco-bot/issues/49