### PR TITLE
NO-JIRA: manifests: bump olm.skipRange upper bound to 4.22.0

### DIFF
--- a/manifests/stable/pf-status-relay-operator.clusterserviceversion.yaml
+++ b/manifests/stable/pf-status-relay-operator.clusterserviceversion.yaml
@@ -25,7 +25,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=4.3.0-0 <4.21.0'
+    olm.skipRange: '>=4.3.0-0 <4.22.0'
     operators.operatorframework.io/builder: operator-sdk-v1.40.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: pf-status-relay-operator.v4.21.0

--- a/manifests/stable/pf-status-relay-operator.clusterserviceversion.yaml
+++ b/manifests/stable/pf-status-relay-operator.clusterserviceversion.yaml
@@ -25,7 +25,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=4.3.0-0 <4.19.0'
+    olm.skipRange: '>=4.3.0-0 <4.21.0'
     operators.operatorframework.io/builder: operator-sdk-v1.40.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: pf-status-relay-operator.v4.21.0


### PR DESCRIPTION
## Summary

- The `art.yaml` substitution for `olm.skipRange` searches for `<{MAJOR}.{MINOR}.0` which expands to `<4.22.0` on main
- The CSV had a stale `<4.19.0` value, causing the ART substitution to silently fail
- Updated `olm.skipRange` from `<4.19.0` to `<4.22.0` so the search pattern matches

Fixes: OCPBUGS-61457