### PR TITLE
Align OCP version to 4.22 and bump operator-sdk to v1.40.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ endif
 
 # Set the Operator SDK version to use. By default, what is installed on the system is used.
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
-OPERATOR_SDK_VERSION ?= v1.37.0
+OPERATOR_SDK_VERSION ?= v1.40.0
 # Image URL to use all building/pushing image targets
 IMG ?= quay.io/openshift/origin-pf-status-relay-operator:$(VERSION)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.

--- a/bundle/manifests/pf-status-relay-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/pf-status-relay-operator.clusterserviceversion.yaml
@@ -28,7 +28,7 @@ metadata:
     olm.skipRange: '>=4.3.0-0 <4.19.0'
     operators.operatorframework.io/builder: operator-sdk-v1.40.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
-  name: pf-status-relay-operator.v4.21.0
+  name: pf-status-relay-operator.v4.22.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -133,12 +133,12 @@ spec:
                 - /manager
                 env:
                 - name: PF_STATUS_RELAY_IMAGE
-                  value: quay.io/openshift/origin-pf-status-relay:4.21.0
+                  value: quay.io/openshift/origin-pf-status-relay:4.22.0
                 - name: WATCH_NAMESPACE
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/openshift/origin-pf-status-relay-operator:4.21.0
+                image: quay.io/openshift/origin-pf-status-relay-operator:4.22.0
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -178,7 +178,7 @@ spec:
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=0
-                image: quay.io/openshift/origin-kube-rbac-proxy:4.21.0
+                image: quay.io/openshift/origin-kube-rbac-proxy:4.22.0
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443
@@ -264,7 +264,7 @@ spec:
   minKubeVersion: 1.30.0
   provider:
     name: openshift
-  version: 4.21.0
+  version: 4.22.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/bundle/manifests/pfstatusrelay.openshift.io_pflacpmonitors.yaml
+++ b/bundle/manifests/pfstatusrelay.openshift.io_pflacpmonitors.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   creationTimestamp: null
   name: pflacpmonitors.pfstatusrelay.openshift.io
 spec:

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -16,7 +16,7 @@ spec:
           capabilities:
             drop:
             - "ALL"
-        image: quay.io/openshift/origin-kube-rbac-proxy:4.21.0
+        image: quay.io/openshift/origin-kube-rbac-proxy:4.22.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/config/manager/env_patch.yaml
+++ b/config/manager/env_patch.yaml
@@ -10,4 +10,4 @@ spec:
         - name: manager
           env:
             - name: PF_STATUS_RELAY_IMAGE
-              value: quay.io/openshift/origin-pf-status-relay:4.21.0
+              value: quay.io/openshift/origin-pf-status-relay:4.22.0

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -7,4 +7,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/openshift/origin-pf-status-relay-operator
-  newTag: 4.21.0
+  newTag: 4.22.0

--- a/hack/align-ocp-version.sh
+++ b/hack/align-ocp-version.sh
@@ -1,6 +1,6 @@
 set -e
 
-export VERSION="4.21.0"
+export VERSION="4.22.0"
 
 sed -i 's/quay.io\/openshift\/origin-pf-status-relay:.*$/quay.io\/openshift\/origin-pf-status-relay:'$VERSION'/g' config/manager/env_patch.yaml
 sed -i 's/quay.io\/openshift\/origin-kube-rbac-proxy:.*$/quay.io\/openshift\/origin-kube-rbac-proxy:'$VERSION'/g' config/default/manager_auth_proxy_patch.yaml

--- a/manifests/pf-status-relay-operator.package.yaml
+++ b/manifests/pf-status-relay-operator.package.yaml
@@ -1,4 +1,4 @@
 packageName: pf-status-relay-operator
 channels:
   - name: "stable"
-    currentCSV: pf-status-relay-operator.v4.21.0
+    currentCSV: pf-status-relay-operator.v4.22.0

--- a/manifests/stable/image-references
+++ b/manifests/stable/image-references
@@ -6,12 +6,12 @@ spec:
   - name: pf-status-relay-operator
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-pf-status-relay-operator:4.21.0
+      name: quay.io/openshift/origin-pf-status-relay-operator:4.22.0
   - name: pf-status-relay
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-pf-status-relay:4.21.0
+      name: quay.io/openshift/origin-pf-status-relay:4.22.0
   - name: kube-rbac-proxy
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-kube-rbac-proxy:4.21.0
+      name: quay.io/openshift/origin-kube-rbac-proxy:4.22.0

--- a/manifests/stable/pf-status-relay-operator.clusterserviceversion.yaml
+++ b/manifests/stable/pf-status-relay-operator.clusterserviceversion.yaml
@@ -28,7 +28,7 @@ metadata:
     olm.skipRange: '>=4.3.0-0 <4.19.0'
     operators.operatorframework.io/builder: operator-sdk-v1.40.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
-  name: pf-status-relay-operator.v4.21.0
+  name: pf-status-relay-operator.v4.22.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -133,12 +133,12 @@ spec:
                 - /manager
                 env:
                 - name: PF_STATUS_RELAY_IMAGE
-                  value: quay.io/openshift/origin-pf-status-relay:4.21.0
+                  value: quay.io/openshift/origin-pf-status-relay:4.22.0
                 - name: WATCH_NAMESPACE
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/openshift/origin-pf-status-relay-operator:4.21.0
+                image: quay.io/openshift/origin-pf-status-relay-operator:4.22.0
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -178,7 +178,7 @@ spec:
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=0
-                image: quay.io/openshift/origin-kube-rbac-proxy:4.21.0
+                image: quay.io/openshift/origin-kube-rbac-proxy:4.22.0
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443
@@ -264,7 +264,7 @@ spec:
   minKubeVersion: 1.30.0
   provider:
     name: openshift
-  version: 4.21.0
+  version: 4.22.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/manifests/stable/pfstatusrelay.openshift.io_pflacpmonitors.yaml
+++ b/manifests/stable/pfstatusrelay.openshift.io_pflacpmonitors.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   creationTimestamp: null
   name: pflacpmonitors.pfstatusrelay.openshift.io
 spec:


### PR DESCRIPTION
Align OCP version to 4.22 and bump operator-sdk to v1.40.0.

operator-sdk was previously at v1.40.0 but was accidentally downgraded to
v1.37.0 by commit fa1acd7 (Marcelo Guerrero Viveros, 2025-08-12,
"Revert 'Add network policies for operator and operand'"). That revert
collaterally reset the Makefile OPERATOR_SDK_VERSION. This PR restores it.

Assisted-By: Claude