### PR TITLE
OLM: support both OwnNamespace and AllNamespaces install modes

### DIFF
--- a/bundle/manifests/pf-status-relay-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/pf-status-relay-operator.clusterserviceversion.yaml
@@ -100,10 +100,6 @@ spec:
                 env:
                 - name: PF_STATUS_RELAY_IMAGE
                   value: quay.io/openshift/origin-pf-status-relay:4.23.0
-                - name: WATCH_NAMESPACE
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.annotations['olm.targetNamespaces']
                 image: quay.io/openshift/origin-pf-status-relay-operator:4.23.0
                 livenessProbe:
                   httpGet:
@@ -245,7 +241,7 @@ spec:
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: false
+  - supported: true
     type: AllNamespaces
   keywords:
   - pf-status-relay

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -236,11 +236,9 @@ func main() {
 }
 
 func getWatchNamespace() (string, error) {
-	var watchNamespaceEnvVar = "WATCH_NAMESPACE"
-
-	ns, found := os.LookupEnv(watchNamespaceEnvVar)
-	if !found {
-		return "", fmt.Errorf("%s must be set", watchNamespaceEnvVar)
+	podNS, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	if err != nil {
+		return "", fmt.Errorf("cannot read pod namespace: %w", err)
 	}
-	return ns, nil
+	return string(podNS), nil
 }

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -72,11 +72,6 @@ spec:
             - --leader-elect
           image: controller:latest
           name: manager
-          env:
-            - name: WATCH_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
           ports:
             - containerPort: 8443
               name: https

--- a/config/manifests/bases/pf-status-relay-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/pf-status-relay-operator.clusterserviceversion.yaml
@@ -39,7 +39,7 @@ spec:
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: false
+  - supported: true
     type: AllNamespaces
   keywords:
   - pf-status-relay

--- a/manifests/stable/pf-status-relay-operator.clusterserviceversion.yaml
+++ b/manifests/stable/pf-status-relay-operator.clusterserviceversion.yaml
@@ -100,10 +100,6 @@ spec:
                 env:
                 - name: PF_STATUS_RELAY_IMAGE
                   value: quay.io/openshift/origin-pf-status-relay:4.23.0
-                - name: WATCH_NAMESPACE
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.annotations['olm.targetNamespaces']
                 image: quay.io/openshift/origin-pf-status-relay-operator:4.23.0
                 livenessProbe:
                   httpGet:
@@ -245,7 +241,7 @@ spec:
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: false
+  - supported: true
     type: AllNamespaces
   keywords:
   - pf-status-relay


### PR DESCRIPTION
## Summary

Operator is installed in namespace X and only watches CRs in that
namespace, independent of OLM install mode.

OLMv1 only supports AllNamespaces — CSV declares both modes for
OLMv0-to-OLMv1 transition.

## Changes

- CSV: AllNamespaces `supported: true` (was false)
- `cmd/main.go`: read namespace from pod service account instead of `WATCH_NAMESPACE` env var
- Remove `WATCH_NAMESPACE` env var from deployment and CSVs (no longer used)

Ref: [CNF-23024](https://issues.redhat.com/browse/CNF-23024)

Assisted-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled installation and operation across all namespaces.
  * Improved namespace detection using the operator’s service account configuration.

* **Bug Fixes**
  * Standardized operator namespace configuration across deployment manifests.
  * Added clearer error handling when the namespace configuration cannot be read.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->