### PR TITLE
Improvements

### DIFF
--- a/bundle/manifests/pf-status-relay-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/pf-status-relay-operator.clusterserviceversion.yaml
@@ -49,50 +49,6 @@ spec:
       clusterPermissions:
       - rules:
         - apiGroups:
-          - apps
-          resources:
-          - daemonsets
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - apps
-          resources:
-          - daemonsets/status
-          verbs:
-          - get
-        - apiGroups:
-          - pfstatusrelay.openshift.io
-          resources:
-          - pflacpmonitors
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - pfstatusrelay.openshift.io
-          resources:
-          - pflacpmonitors/finalizers
-          verbs:
-          - update
-        - apiGroups:
-          - pfstatusrelay.openshift.io
-          resources:
-          - pflacpmonitors/status
-          verbs:
-          - get
-          - patch
-          - update
-        - apiGroups:
           - authentication.k8s.io
           resources:
           - tokenreviews
@@ -239,6 +195,50 @@ spec:
           verbs:
           - create
           - patch
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets/status
+          verbs:
+          - get
+        - apiGroups:
+          - pfstatusrelay.openshift.io
+          resources:
+          - pflacpmonitors
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - pfstatusrelay.openshift.io
+          resources:
+          - pflacpmonitors/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - pfstatusrelay.openshift.io
+          resources:
+          - pflacpmonitors/status
+          verbs:
+          - get
+          - patch
+          - update
         serviceAccountName: pf-status-relay-operator-controller-manager
     strategy: deployment
   installModes:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,8 +1,9 @@
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: manager-role
+  namespace: system
 rules:
 - apiGroups:
   - apps

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -1,5 +1,5 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: pf-status-relay-operator
@@ -7,7 +7,7 @@ metadata:
   name: manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: manager-role
 subjects:
 - kind: ServiceAccount

--- a/internal/controller/pflacpmonitor_controller.go
+++ b/internal/controller/pflacpmonitor_controller.go
@@ -48,11 +48,11 @@ type PFLACPMonitorReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=pfstatusrelay.openshift.io,resources=pflacpmonitors,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=pfstatusrelay.openshift.io,resources=pflacpmonitors/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=pfstatusrelay.openshift.io,resources=pflacpmonitors/finalizers,verbs=update
-// +kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=apps,resources=daemonsets/status,verbs=get
+// +kubebuilder:rbac:groups=pfstatusrelay.openshift.io,resources=pflacpmonitors,verbs=get;list;watch;create;update;patch;delete,namespace=system
+// +kubebuilder:rbac:groups=pfstatusrelay.openshift.io,resources=pflacpmonitors/status,verbs=get;update;patch,namespace=system
+// +kubebuilder:rbac:groups=pfstatusrelay.openshift.io,resources=pflacpmonitors/finalizers,verbs=update,namespace=system
+// +kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch;create;update;patch;delete,namespace=system
+// +kubebuilder:rbac:groups=apps,resources=daemonsets/status,verbs=get,namespace=system
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/internal/controller/pflacpmonitor_controller.go
+++ b/internal/controller/pflacpmonitor_controller.go
@@ -151,7 +151,6 @@ func (r *PFLACPMonitorReconciler) syncDaemonSet(ctx context.Context, pfMonitor *
 				Spec: corev1.PodSpec{
 					ServiceAccountName: pfStatusRelaySAName,
 					HostNetwork:        true,
-					HostPID:            true,
 					NodeSelector:       pfMonitor.Spec.NodeSelector,
 					Containers: []corev1.Container{
 						{

--- a/manifests/stable/pf-status-relay-operator.clusterserviceversion.yaml
+++ b/manifests/stable/pf-status-relay-operator.clusterserviceversion.yaml
@@ -49,50 +49,6 @@ spec:
       clusterPermissions:
       - rules:
         - apiGroups:
-          - apps
-          resources:
-          - daemonsets
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - apps
-          resources:
-          - daemonsets/status
-          verbs:
-          - get
-        - apiGroups:
-          - pfstatusrelay.openshift.io
-          resources:
-          - pflacpmonitors
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - pfstatusrelay.openshift.io
-          resources:
-          - pflacpmonitors/finalizers
-          verbs:
-          - update
-        - apiGroups:
-          - pfstatusrelay.openshift.io
-          resources:
-          - pflacpmonitors/status
-          verbs:
-          - get
-          - patch
-          - update
-        - apiGroups:
           - authentication.k8s.io
           resources:
           - tokenreviews
@@ -239,6 +195,50 @@ spec:
           verbs:
           - create
           - patch
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets/status
+          verbs:
+          - get
+        - apiGroups:
+          - pfstatusrelay.openshift.io
+          resources:
+          - pflacpmonitors
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - pfstatusrelay.openshift.io
+          resources:
+          - pflacpmonitors/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - pfstatusrelay.openshift.io
+          resources:
+          - pflacpmonitors/status
+          verbs:
+          - get
+          - patch
+          - update
         serviceAccountName: pf-status-relay-operator-controller-manager
     strategy: deployment
   installModes:


### PR DESCRIPTION
- drop hostPID from rendered DaemonSet 
- rbac: scope reconciler permissions to the install namespace 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved and consolidated operator RBAC into namespace-scoped roles/permissions to tighten permission boundaries.
  * Adjusted authorization for custom resource status and finalizers, adding needed verbs for proper status updates and lifecycle handling.

* **Chores**
  * Removed host PID namespace access from operator pods to improve isolation and security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->