### PR TITLE
Align OCP version to 4.23

### DIFF
--- a/bundle/manifests/pf-status-relay-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/pf-status-relay-operator.clusterserviceversion.yaml
@@ -25,10 +25,10 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=4.3.0-0 <4.19.0'
+    olm.skipRange: '>=4.3.0-0 <4.23.0'
     operators.operatorframework.io/builder: operator-sdk-v1.40.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
-  name: pf-status-relay-operator.v4.22.0
+  name: pf-status-relay-operator.v4.23.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -99,12 +99,12 @@ spec:
                 - /manager
                 env:
                 - name: PF_STATUS_RELAY_IMAGE
-                  value: quay.io/openshift/origin-pf-status-relay:4.22.0
+                  value: quay.io/openshift/origin-pf-status-relay:4.23.0
                 - name: WATCH_NAMESPACE
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/openshift/origin-pf-status-relay-operator:4.22.0
+                image: quay.io/openshift/origin-pf-status-relay-operator:4.23.0
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -261,7 +261,7 @@ spec:
   minKubeVersion: 1.30.0
   provider:
     name: openshift
-  version: 4.22.0
+  version: 4.23.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/config/manager/env_patch.yaml
+++ b/config/manager/env_patch.yaml
@@ -10,4 +10,4 @@ spec:
         - name: manager
           env:
             - name: PF_STATUS_RELAY_IMAGE
-              value: quay.io/openshift/origin-pf-status-relay:4.22.0
+              value: quay.io/openshift/origin-pf-status-relay:4.23.0

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -9,4 +9,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/openshift/origin-pf-status-relay-operator
-  newTag: 4.22.0
+  newTag: 4.23.0

--- a/config/manifests/bases/pf-status-relay-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/pf-status-relay-operator.clusterserviceversion.yaml
@@ -11,7 +11,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=4.3.0-0 <4.19.0'
+    olm.skipRange: '>=4.3.0-0 <4.23.0'
   name: pf-status-relay-operator.v0.0.0
   namespace: placeholder
 spec:

--- a/hack/align-ocp-version.sh
+++ b/hack/align-ocp-version.sh
@@ -1,6 +1,6 @@
 set -e
 
-export VERSION="4.22.0"
+export VERSION="4.23.0"
 
 sed -i 's/quay.io\/openshift\/origin-pf-status-relay:.*$/quay.io\/openshift\/origin-pf-status-relay:'$VERSION'/g' config/manager/env_patch.yaml
 make bundle

--- a/manifests/pf-status-relay-operator.package.yaml
+++ b/manifests/pf-status-relay-operator.package.yaml
@@ -1,4 +1,4 @@
 packageName: pf-status-relay-operator
 channels:
   - name: "stable"
-    currentCSV: pf-status-relay-operator.v4.22.0
+    currentCSV: pf-status-relay-operator.v4.23.0

--- a/manifests/stable/image-references
+++ b/manifests/stable/image-references
@@ -6,8 +6,8 @@ spec:
   - name: pf-status-relay-operator
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-pf-status-relay-operator:4.22.0
+      name: quay.io/openshift/origin-pf-status-relay-operator:4.23.0
   - name: pf-status-relay
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-pf-status-relay:4.22.0
+      name: quay.io/openshift/origin-pf-status-relay:4.23.0

--- a/manifests/stable/pf-status-relay-operator.clusterserviceversion.yaml
+++ b/manifests/stable/pf-status-relay-operator.clusterserviceversion.yaml
@@ -25,10 +25,10 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=4.3.0-0 <4.19.0'
+    olm.skipRange: '>=4.3.0-0 <4.23.0'
     operators.operatorframework.io/builder: operator-sdk-v1.40.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
-  name: pf-status-relay-operator.v4.22.0
+  name: pf-status-relay-operator.v4.23.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -99,12 +99,12 @@ spec:
                 - /manager
                 env:
                 - name: PF_STATUS_RELAY_IMAGE
-                  value: quay.io/openshift/origin-pf-status-relay:4.22.0
+                  value: quay.io/openshift/origin-pf-status-relay:4.23.0
                 - name: WATCH_NAMESPACE
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/openshift/origin-pf-status-relay-operator:4.22.0
+                image: quay.io/openshift/origin-pf-status-relay-operator:4.23.0
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -261,7 +261,7 @@ spec:
   minKubeVersion: 1.30.0
   provider:
     name: openshift
-  version: 4.22.0
+  version: 4.23.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1


### PR DESCRIPTION
## Summary

Bump CSV version label from 4.22.0 to 4.23.0 and update stale `olm.skipRange`.

The 4.23 FBC build already ships the correct code (commit 953873b with the security fix),
but the CSV metadata still says v4.22.0 — this is a cosmetic label fix, not a code change.
The version string appears when inspecting the operator via `oc get csv` or OLM UI.

Also fixes `olm.skipRange` upper bound which was stuck at `<4.19.0` since that release
(should track current version, matching sriov-network-operator convention).

## Changes
- `hack/align-ocp-version.sh`: VERSION 4.22.0 -> 4.23.0
- `config/manifests/bases/`: skipRange `<4.19.0` -> `<4.23.0`
- Regenerated bundle, manifests, image-references via `hack/align-ocp-version.sh`

Assisted-By: Claude