### PR TITLE
rbac: add namespace-scoped NetworkPolicy permissions

### DIFF
--- a/bundle/manifests/pf-status-relay-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/pf-status-relay-operator.clusterserviceversion.yaml
@@ -211,6 +211,15 @@ spec:
           verbs:
           - get
         - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - delete
+          - patch
+          - update
+        - apiGroups:
           - pfstatusrelay.openshift.io
           resources:
           - pflacpmonitors

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -50,6 +50,15 @@ rules:
   verbs:
   - get
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
   - pfstatusrelay.openshift.io
   resources:
   - pflacpmonitors

--- a/internal/controller/pflacpmonitor_controller.go
+++ b/internal/controller/pflacpmonitor_controller.go
@@ -53,6 +53,7 @@ type PFLACPMonitorReconciler struct {
 // +kubebuilder:rbac:groups=pfstatusrelay.openshift.io,resources=pflacpmonitors/finalizers,verbs=update,namespace=system
 // +kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch;create;update;patch;delete,namespace=system
 // +kubebuilder:rbac:groups=apps,resources=daemonsets/status,verbs=get,namespace=system
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=create;delete;update;patch,namespace=system
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/manifests/stable/pf-status-relay-operator.clusterserviceversion.yaml
+++ b/manifests/stable/pf-status-relay-operator.clusterserviceversion.yaml
@@ -211,6 +211,15 @@ spec:
           verbs:
           - get
         - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - delete
+          - patch
+          - update
+        - apiGroups:
           - pfstatusrelay.openshift.io
           resources:
           - pflacpmonitors


### PR DESCRIPTION
Comply with Conforma policy olm.required_network_policy_rbac_for_operands ([KONFLUX-13290](https://redhat.atlassian.net/browse/KONFLUX-13290)). Even though operand currently does not need network policies, we add them scoped to the operator namespace to enable the metrics endpoint protection use case in the future.

Uses explicit verbs (create/delete/update/patch) instead of wildcard, and namespace=system marker to generate a Role (not ClusterRole) under CSV permissions.

Assisted-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The operator can now manage Kubernetes NetworkPolicies.
  * Updated permissions allow creating, updating, patching, and deleting NetworkPolicies where needed.

* **Chores**
  * Aligned deployment and permission manifests with the new NetworkPolicy access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->