### PR TITLE
controller: tighten DaemonSet container security context

### DIFF
--- a/internal/controller/pflacpmonitor_controller.go
+++ b/internal/controller/pflacpmonitor_controller.go
@@ -157,7 +157,15 @@ func (r *PFLACPMonitorReconciler) syncDaemonSet(ctx context.Context, pfMonitor *
 							Name:  "pf-status-relay",
 							Image: image,
 							SecurityContext: &corev1.SecurityContext{
-								Privileged: func(b bool) *bool { return &b }(true),
+								AllowPrivilegeEscalation: func(b bool) *bool { return &b }(false),
+								ReadOnlyRootFilesystem:   func(b bool) *bool { return &b }(true),
+								Capabilities: &corev1.Capabilities{
+									Drop: []corev1.Capability{"ALL"},
+									Add:  []corev1.Capability{"NET_ADMIN"},
+								},
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: corev1.SeccompProfileTypeRuntimeDefault,
+								},
 							},
 							Env: []corev1.EnvVar{
 								{

--- a/internal/controller/pflacpmonitor_controller.go
+++ b/internal/controller/pflacpmonitor_controller.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -157,8 +158,8 @@ func (r *PFLACPMonitorReconciler) syncDaemonSet(ctx context.Context, pfMonitor *
 							Name:  "pf-status-relay",
 							Image: image,
 							SecurityContext: &corev1.SecurityContext{
-								AllowPrivilegeEscalation: func(b bool) *bool { return &b }(false),
-								ReadOnlyRootFilesystem:   func(b bool) *bool { return &b }(true),
+								AllowPrivilegeEscalation: ptr.To(false),
+								ReadOnlyRootFilesystem:   ptr.To(true),
 								Capabilities: &corev1.Capabilities{
 									Drop: []corev1.Capability{"ALL"},
 									Add:  []corev1.Capability{"NET_ADMIN"},

--- a/internal/controller/pflacpmonitor_controller_test.go
+++ b/internal/controller/pflacpmonitor_controller_test.go
@@ -114,6 +114,19 @@ var _ = Describe("PFLACPMonitor Controller", func() {
 				Expect(ds.Spec.Template.Spec.Containers[0].Image).To(Equal(dsImage))
 				Expect(ds.Spec.Template.Spec.Containers[0].Env).To(Equal(envVars))
 				Expect(ds.Spec.Template.Spec.NodeSelector).To(Equal(map[string]string{"key": "value"}))
+
+				sc := ds.Spec.Template.Spec.Containers[0].SecurityContext
+				Expect(sc).NotTo(BeNil())
+				Expect(sc.Privileged).To(BeNil())
+				Expect(sc.AllowPrivilegeEscalation).NotTo(BeNil())
+				Expect(*sc.AllowPrivilegeEscalation).To(BeFalse())
+				Expect(sc.ReadOnlyRootFilesystem).NotTo(BeNil())
+				Expect(*sc.ReadOnlyRootFilesystem).To(BeTrue())
+				Expect(sc.Capabilities).NotTo(BeNil())
+				Expect(sc.Capabilities.Drop).To(ConsistOf(corev1.Capability("ALL")))
+				Expect(sc.Capabilities.Add).To(ConsistOf(corev1.Capability("NET_ADMIN")))
+				Expect(sc.SeccompProfile).NotTo(BeNil())
+				Expect(sc.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
 			})
 
 			It("recreates the DeamonSet when this has been deleted", func() {


### PR DESCRIPTION
## Summary

- Remove broad privilege grant from the relay DaemonSet container; replace with scoped capability and explicit hardening fields
- Add unit test coverage for container security context

## Test plan

- [ ] `make test` passes
- [ ] DaemonSet pod starts on SR-IOV node and relay operates normally with `PFLACPMonitor` CR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Hardened the `pf-status-relay` daemonset container security settings by removing privileged mode, disabling privilege escalation, enforcing a read-only root filesystem, dropping all Linux capabilities while allowing only `NET_ADMIN`, and applying a `RuntimeDefault` seccomp profile.
* **Bug Fixes**
  * Enhanced the daemonset configuration test to verify the container’s security context matches the expected privilege, capabilities, filesystem, and seccomp settings during deployment validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->