### PR TITLE
OCPBUGS-99742: Bump CSV version from 4.21.0 to 4.22.0

### DIFF
--- a/manifests/pf-status-relay-operator.package.yaml
+++ b/manifests/pf-status-relay-operator.package.yaml
@@ -1,4 +1,4 @@
 packageName: pf-status-relay-operator
 channels:
   - name: "stable"
-    currentCSV: pf-status-relay-operator.v4.21.0
+    currentCSV: pf-status-relay-operator.v4.22.0

--- a/manifests/stable/pf-status-relay-operator.clusterserviceversion.yaml
+++ b/manifests/stable/pf-status-relay-operator.clusterserviceversion.yaml
@@ -25,10 +25,10 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=4.3.0-0 <4.19.0'
+    olm.skipRange: '>=4.3.0-0 <4.22.0'
     operators.operatorframework.io/builder: operator-sdk-v1.40.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
-  name: pf-status-relay-operator.v4.21.0
+  name: pf-status-relay-operator.v4.22.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -264,7 +264,7 @@ spec:
   minKubeVersion: 1.30.0
   provider:
     name: openshift
-  version: 4.21.0
+  version: 4.22.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1


### PR DESCRIPTION
  CSV metadata.name, spec.version, olm.skipRange, and package.yaml
  currentCSV still had 4.21.0 on the release-4.22 branch. This causes
  ART's art.yaml search-and-replace to silently fail because it searches
  for v4.22.0 patterns that don't exist in the source.

  Also bumps olm.skipRange from <4.19.0 to <4.22.0.

  Fixes: OCPBUGS-99742

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED