### PR TITLE
OCPBUGS-105560: Bump CSV version from 4.23.0 to 5.0.0 on release-5.0

### DIFF
--- a/manifests/pf-status-relay-operator.package.yaml
+++ b/manifests/pf-status-relay-operator.package.yaml
@@ -1,4 +1,4 @@
 packageName: pf-status-relay-operator
 channels:
   - name: "stable"
-    currentCSV: pf-status-relay-operator.v4.23.0
+    currentCSV: pf-status-relay-operator.v5.0.0

--- a/manifests/stable/pf-status-relay-operator.clusterserviceversion.yaml
+++ b/manifests/stable/pf-status-relay-operator.clusterserviceversion.yaml
@@ -25,10 +25,10 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=4.3.0-0 <4.23.0'
+    olm.skipRange: '>=4.3.0-0 <5.0.0'
     operators.operatorframework.io/builder: operator-sdk-v1.40.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
-  name: pf-status-relay-operator.v4.23.0
+  name: pf-status-relay-operator.v5.0.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -266,7 +266,7 @@ spec:
   minKubeVersion: 1.30.0
   provider:
     name: openshift
-  version: 4.23.0
+  version: 5.0.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1


### PR DESCRIPTION
Bump CSV version from 4.23.0 to 5.0.0 on the `release-5.0` branch.

Files updated:
- `manifests/pf-status-relay-operator.package.yaml`: `currentCSV`
- `manifests/stable/pf-status-relay-operator.clusterserviceversion.yaml`: `metadata.name`, `olm.skipRange`, `spec.version`

Jira: [OCPBUGS-105560](https://redhat.atlassian.net/browse/OCPBUGS-105560)